### PR TITLE
Header now displays only relevant staff page #47

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -107,26 +107,52 @@ const App = () => {
 					/>
 				</Route>
 				<Route
-					element={
-						<PrivateRoute
-							userRole={userRole}
-							allowed={["admin", "finance", "committee", "allocator"]}
-						/>
-					}
+					element={<PrivateRoute userRole={userRole} allowed={["super"]} />}
 				>
 					<Route path="/staff" element={<StaffPortal />} />
+				</Route>
+				<Route
+					element={
+						<PrivateRoute userRole={userRole} allowed={["finance", "super"]} />
+					}
+				>
 					<Route
 						path="/staff/finance"
 						element={<Finance client={client} token={token} />}
 					/>
+				</Route>
+
+				<Route
+					element={
+						<PrivateRoute
+							userRole={userRole}
+							allowed={["allocator", "super"]}
+						/>
+					}
+				>
 					<Route
 						path="/staff/allocation"
 						element={<Allocation client={client} token={token} />}
 					/>
+				</Route>
+				<Route
+					element={
+						<PrivateRoute
+							userRole={userRole}
+							allowed={["allocator", "super", "finance,", "admin", "committee"]}
+						/>
+					}
+				>
 					<Route
 						path="/staff/committee"
 						element={<Committee client={client} token={token} />}
 					/>
+				</Route>
+				<Route
+					element={
+						<PrivateRoute userRole={userRole} allowed={["admin", "super"]} />
+					}
+				>
 					<Route
 						path="/staff/admin"
 						element={<Admin client={client} token={token} />}

--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -1,6 +1,6 @@
 import axios from "axios";
-// const url = "http://localhost:3001/";
-const url = "https://stannington-carnival-backend.onrender.com/";
+const url = "http://localhost:3001/";
+// const url = "https://stannington-carnival-backend.onrender.com/";
 
 export class ApiClient {
 	constructor(tokenProvider, logoutHandler) {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -13,6 +13,12 @@ const Navbar = (props) => {
 		changeToken(undefined);
 	};
 
+	function capitalizeFirstLetter(string) {
+		if (string) {
+			return string.charAt(0).toUpperCase() + string.slice(1);
+		}
+	}
+
 	// Handles changing userRole state (when user token changes)
 	useEffect(() => {
 		const callApi = async () => {
@@ -51,13 +57,35 @@ const Navbar = (props) => {
 				>
 					<button className="nav-btn">Login</button>
 				</Link>
+
 				{["admin", "finance", "committee", "allocator"].includes(userRole) ? (
-					<Link to="/staff">
-						<button className="nav-btn">Staff Portal</button>
-					</Link>
+					<>
+						<Link to="/staff/committee">
+							<button className="nav-btn">View Statistics</button>
+						</Link>
+						<Link to={`/staff/${userRole}`}>
+							<button className="nav-btn">{`${capitalizeFirstLetter(
+								userRole
+							)} Page`}</button>
+						</Link>
+					</>
 				) : (
 					<></>
 				)}
+
+				{["super"].includes(userRole) ? (
+					<>
+						<Link to="/staff/committee">
+							<button className="nav-btn">View Statistics</button>
+						</Link>
+						<Link to="/staff">
+							<button className="nav-btn">Staff Pages</button>
+						</Link>
+					</>
+				) : (
+					<></>
+				)}
+
 				<Link to={!props.token ? "/login" : "/bookings/new"}>
 					<button className="nav-btn">Book</button>
 				</Link>


### PR DESCRIPTION
- Created a new user type 'super' for testing, which has access to the old page which contains links to all the staff pages.
- All the other staff members will only have access to their own staff page - it is accessible directly from the header.
- Each staff member now has access to the Committee page (Renamed to 'Statistics Page' for now, can maybe change) at Neil's request.
- Individual Private routes have been setup to disallow staff members from unintentionally accessing one another's pages.

'Super' staff member will see this:
![image](https://user-images.githubusercontent.com/56947241/204260152-5e38aade-774f-49d9-8a22-e4a1d157145b.png)

Logged out user will see this:
![image](https://user-images.githubusercontent.com/56947241/204260366-50c1e810-d6de-4c5c-9e08-222ae7e08e33.png)

'Admin' user will see this:
![image](https://user-images.githubusercontent.com/56947241/204260436-a56e69fa-32f1-418d-b9a3-61cd6cb64042.png)
