### PR TITLE
Stall holders can now edit/delete their own bookings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -101,7 +101,7 @@ const App = () => {
 							<>
 								{" "}
 								<h1 className="header-font title centered">Your bookings:</h1>
-								<ViewBookings client={client} token={token} />
+								<ViewBookings view="holder" client={client} token={token} />
 							</>
 						}
 					/>

--- a/src/components/BookingCard.jsx
+++ b/src/components/BookingCard.jsx
@@ -84,14 +84,12 @@ const BookingCard = (props) => {
 		props.updated((prev) => prev + 1);
 	};
 
-	// TODO: Thisss is too buggy to use right now
+	// FIXME: editableFields.type not getting initialised by it's useState
 	const cycleStatus = () => {
 		let typeList = Object.keys(bookingTypes);
-		let currentIndex = typeList.indexOf(editableFields.type);
+		let currentIndex = typeList.indexOf(editableFields.type) + 1;
 		if (currentIndex >= typeList.length - 1) {
 			currentIndex = 0;
-		} else {
-			currentIndex++;
 		}
 		setEditableFields({
 			...editableFields,
@@ -139,7 +137,7 @@ const BookingCard = (props) => {
 				<div
 					className="fb row gap-1"
 					style={
-						isHovered && props.view === "admin"
+						isHovered && ["admin", "holder"].includes(props.view)
 							? { display: "flex" }
 							: { display: "none" }
 					}


### PR DESCRIPTION
Ignore any changes to cycleStatus. That's to do with editing the BookingCard's booking type (e.g. Craft, Commercial), it still isn't working.

We're not really able to demonstrate Stall Holder editing working yet, we'll need to edit the backend's role requirements for updating bookings, it's currently only allowed by admin officers so at the moment it just gives a 403 status code.

![image](https://user-images.githubusercontent.com/56947241/205896864-7f644097-11bb-40bb-9713-ba70691ae685.png)
