### PR TITLE
All bookings are now displayed on Staff Page load #84

### DIFF
--- a/src/components/Admin.jsx
+++ b/src/components/Admin.jsx
@@ -104,7 +104,7 @@ const Admin = (props) => {
 						className="header-font finance-header centered"
 						style={{ width: "100%", height: "100%" }}
 					>
-						Begin by selecting a user to view their bookings.
+						User has never logged in.
 					</div>
 				)}
 			</div>

--- a/src/components/Allocation.jsx
+++ b/src/components/Allocation.jsx
@@ -105,7 +105,7 @@ const Allocation = (props) => {
 						className="header-font finance-header centered"
 						style={{ width: "100%", height: "100%" }}
 					>
-						Begin by selecting a user to view their bookings.
+						User has never logged in.
 					</div>
 				)}
 			</div>

--- a/src/components/BookingCard.jsx
+++ b/src/components/BookingCard.jsx
@@ -254,7 +254,6 @@ const BookingCard = (props) => {
 									&nbsp;
 									{props.telephone}
 								</p>
-								{console.log(props)}
 								<p className="contact-info-container">
 									<FaRegCalendarAlt />
 									&nbsp;

--- a/src/components/Finance.jsx
+++ b/src/components/Finance.jsx
@@ -50,7 +50,7 @@ const Finance = (props) => {
 						className="header-font finance-header centered"
 						style={{ width: "100%", height: "100%" }}
 					>
-						Begin by selecting a user to view their bookings.
+						User has never logged in.
 					</div>
 				)}
 			</div>

--- a/src/components/UserList.jsx
+++ b/src/components/UserList.jsx
@@ -14,6 +14,10 @@ const UserList = (props) => {
 		callApi();
 	}, [props.client, props.token]);
 
+	useEffect(() => {
+		props.setSelectedStatus("all");
+	}, []);
+
 	const buildUsers = () => {
 		let existingUsers = users
 			?.filter((user) => {
@@ -71,6 +75,13 @@ const UserList = (props) => {
 				>
 					<FaTimesCircle />
 					Unpaid
+				</div>
+				<div
+					className="card-type centered pointer"
+					style={{ backgroundColor: "#1996fc", marginInline: "1rem" }}
+					onClick={() => changeStatusFilter("all")}
+				>
+					View All
 				</div>
 			</div>
 

--- a/src/components/ViewBookings.jsx
+++ b/src/components/ViewBookings.jsx
@@ -8,15 +8,22 @@ const ViewBookings = (props) => {
 
 	useEffect(() => {
 		const callApi = async () => {
-			if (props.user === undefined) {
-				if (props.status !== undefined) {
-					setBookings((await props.client.getByStatus(props.status)).data);
-				} else {
-					setBookings((await props.client.getMyBookings(props.token)).data);
-				}
-			} else {
+			if (props.user) {
+				// If a user has been selected...
 				setBookings((await props.client.getMyBookings(props.user)).data);
+				return;
 			}
+			if (props.status === "all") {
+				// If all cards are selected (i.e. on Staff Page load...)
+				setBookings((await props.client.getAllBookings()).data);
+				return;
+			}
+			if (["paid", "unpaid"].includes(props.status)) {
+				setBookings((await props.client.getByStatus(props.status)).data);
+				return;
+			}
+			// If no filters were selected... (i.e. on My Bookings Page)
+			setBookings((await props.client.getMyBookings(props.token)).data);
 		};
 		callApi();
 		/*eslint-disable*/


### PR DESCRIPTION
Added a View All button also so that the Staff user can go back to viewing all bookings whenever they want.

https://user-images.githubusercontent.com/56947241/206169684-451aa374-303e-403f-9de5-d7227515db81.mp4

Also re-purposed the 'Begin by selecting a user' message, which had a bug associated with it. Previously it displayed when you selected a user that hadn't had a token generated. Now that it can only appear when you select a user that hasn't had a token generated, we just changed the text (Though hopefully, we'll change the backend so that it stores a token in MongoDB upon account creation so that a staff member can create a booking for someone who hasn't logged in before without any problems).

Also did some refactoring to get rid of a horrid triple-nested function.
